### PR TITLE
allows binaries to be copied in powershell

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build-protocol": "cross-env NODE_ENV=production node -r babel-register ./node_modules/webpack/bin/webpack --config webpack.config.protocol.js --progress --profile --colors",
     "build": "concurrently \"npm run build-app\" \"npm run build-api\" \"npm run build-protocol\"",
     "copy-binaries:unix": "cp -f ./system_uri/target/release/*system_uri* ./src/ffi && cp -f ./native/target/release/*safe_authenticator* ./src/ffi",
-    "copy-binaries:win": "cp -f ./system_uri/target/release/system_uri.dll ./src/ffi && cp -f ./native/target/release/safe_authenticator.dll ./src/ffi",
+    "copy-binaries:win": "powershell.exe \"Copy-Item -Path .\\system_uri\\target\\release\\system_uri.dll -Destination .\\src\\ffi -force; if ($?) {Copy-Item -Path .\\native\\target\\release\\safe_authenticator.dll -Destination .\\src\\ffi -force;}\"",
     "build-system-uri": "cd system_uri && cargo clean && cargo update && cargo build --release && cd ../",
     "build-native": "cd ./native/safe_authenticator && cargo clean && cargo update && cargo build --release && cd ../../",
     "build-native-mock": "cd ./native/safe_authenticator && cargo clean && cargo update && cargo build --release --features \"use-mock-routing\" && cd ../../",


### PR DESCRIPTION
When `npm run copy-binaries:win` is executed as part of the command string in `build_libs.js`, NodeJS Child Process seems to spawn a `cmd` shell, which does not recognize the `cp` command, unlike Powershell.

This PR makes a change to `package.json` to allow `npm run copy-binaries:win` to be run on Windows when executed within a CMD shell.

I ran into this issue while compiling `safe_browser` in Powershell on a Windows 10 OS.